### PR TITLE
fix: handle case when `$PATH` has empty entries

### DIFF
--- a/mise.el
+++ b/mise.el
@@ -256,7 +256,8 @@ environments updated."
                            (puthash cache-key new-val mise--cache)
                            new-val))))
         (let ((path (getenv "PATH")))
-          (setq-local exec-path (-map #'directory-file-name (parse-colon-path path)))
+          (setq-local exec-path (-map #'directory-file-name
+                                      (remove nil (parse-colon-path path))))
           (when (derived-mode-p 'eshell-mode)
             (if (fboundp 'eshell-set-path)
                 (eshell-set-path path)


### PR DESCRIPTION
Fix for the case when a user's `$PATH` variable contains a trailing/prefix `:` and thus a `nil` value in the return from `parse-colon-path`.

Stack trace (abridged and redacted):

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  directory-file-name(nil)
  -map(directory-file-name ("<REDACT>" "<REDACT>" nil))
  (set (make-local-variable 'exec-path) (-map #'directory-file-name (parse-colon-path path)))
...
  mise--update()
...
  mise-mode(toggle)
  funcall-interactively(mise-mode toggle)
  command-execute(mise-mode record)
  counsel-M-x-action("mise-mode")
```

To reproduce, run `PATH="$PATH:" emacs` and attempt to activate `mise-mode` or `global-mise-mode`.

Discovered setting up on my apparently misconfigured machine.