### PR TITLE
doc: update required mise version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Heavily inspired from [envrc][envrc] which created by Purcell.
 ### dependencies
 
 - [inheirtenv](https://github.com/purcell/inheritenv)
-- [mise][mise], version >= 2024.4.8
+- [mise][mise], version >= 2024.10.8
 - emacs, version >= 29.1
 - [dash](https://github.com/magnars/dash.el) version >= 2.19.1
 


### PR DESCRIPTION
Using the `--json` option of `mise config ls` raises the required mise version to 2024.10.8.